### PR TITLE
build-list: fix bugs in path manipulation

### DIFF
--- a/dev/build-list/build-list.py
+++ b/dev/build-list/build-list.py
@@ -20,39 +20,42 @@ def replace_extension(fn, is_alias):
     elif ext in ['.cpp','.hpp']:
         # name = os.path.join('_build', name)
         return name + '_' + ext[1:] + '.vo'
-    elif '@' in name:
-        return name
-    elif os.path.isdir(name):
-        return name
+    else:
+        return fn
 
 def node(tag, args):
     return [sexpdata.Symbol(tag)] + args
 
 def parse_target(fn):
-    alias = False
+    tgt_type = False
+    (_, ext) = os.path.splitext(fn)
     if fn.startswith('@@'):
         fn = fn[2:]
-        alias = '@@'
+        tgt_type = '@@'
     elif fn.startswith('@'):
         fn = fn[1:]
-        alias = '@'
-    return (alias, os.path.realpath(fn))
+        tgt_type = '@'
+    elif '*' in fn:
+        tgt_type = 'pattern'
+    else:
+        tgt_type = 'file'
+    return (tgt_type, os.path.realpath(fn))
 
 def make_alias_target(tgt_name, tgts, relative_to):
     deps = []
     tgts = tgts or []
-    for tgt in tgts:
-        (alias, tgt) = parse_target(tgt)
-        tgt = replace_extension(tgt, is_alias=alias)
+    for init_tgt in tgts:
+        (tgt_type, tgt) = parse_target(init_tgt)
+        pwd = os.path.realpath('.')
+        tgt = replace_extension(tgt, is_alias=tgt_type in ['@','@@'])
         tgt_rel_path = os.path.relpath(tgt, relative_to)
-        if tgt:
-            if alias:
-                deps.append(node('alias', [alias + tgt_rel_path]))
-            elif os.path.isdir(tgt):
-                tgt = os.path.join(tgt, '*')
-                deps.append(node('glob_files_rec', [tgt_rel_path]))
-            else:
-                deps.append(node('file', [tgt_rel_path]))
+        if tgt_type in ['@', '@@']:
+            deps.append(node('alias', [alias + tgt_rel_path]))
+        elif tgt_type == 'pattern':
+            tgt = os.path.join(tgt, '*')
+            deps.append(node('glob_files_rec', [tgt_rel_path]))
+        else:
+            deps.append(node('file', [tgt_rel_path]))
 
     name = node('name', [tgt_name])
     deps = node('deps', deps)


### PR DESCRIPTION
The path of a target is made relative to a path other than `pwd` before checking whether the path designates a file or a directory. The file / directory could not be found and the script would fail silently.

This PR fixes this issue. It also corrects the way '@@' aliases are manipulated.