### PR TITLE
[ci,opam] force the dune cache to be enabled.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,7 @@ jobs:
       env:
         NJOBS: "16"
         BASH_ENV: "/home/coq/.profile"
+        DUNE_CACHE: "enabled"
     steps:
       # Here and in other jobs, this is the inverse of "Upload actions and workflows", and it lets us find the correct actions under `./actions`.
       - name: "Download CI files"


### PR DESCRIPTION
Hopefully closing https://github.com/SkylabsAI/workspace/issues/64.

Currently, the cache is enabled at the workspace level, but opam disregards the workspace when it installs packages, so I am hoping that enabling the cache in another way will solve the issue. We could also attempt to write the config to the dune config file.