### PR TITLE
gitignore: .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _build/
 _opam/
 _CoqProject
+.env


### PR DESCRIPTION
We will need to place `.env` files in the `workspace` so they can be shared between `fmdeps` and `psi` (cf. [corresponding line](https://github.com/SkylabsAI/psi-verifier/blob/dfff177dd0478c46eeeb3a91cfe199be01701f91/.gitignore#L125) in `psi-verifier/.gitignore`).