### PR TITLE
Publish BRiCk GitHub pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -274,10 +274,51 @@ jobs:
           cd fmdeps/BRiCk
           make -j ${NJOBS} doc
           mv rocq-bluerock-brick/doc/sphinx/_build/html ${{ env.SCRATCHDIR }}/html
-      - name: "Upload static files as artifact"
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ${{ env.SCRATCHDIR }}/html
+      - name: "Prepare and push to BRiCk's gh-pages branch"
+        run: |
+          source ${{ env.BOILERPLATE }}
+          cd fmdeps/BRiCk
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
+          git config --local remote.origin.fetch "+refs/heads/gh-pages:refs/remotes/origin/gh-pages"
+          let attempt=1
+          while [[ $attempt -le 10 ]]; do
+            echo "Attempt number $attempt"
+            git fetch origin
+            git checkout -b gh-pages origin/gh-pages
+            git rm -r --quiet docs
+            cp -r ${{ env.SCRATCHDIR }}/html docs
+            touch docs/.nojekyll
+            git add -f docs
+            if git diff-index --quiet HEAD; then
+              echo "No changes to the BRiCk documentation."
+              exit 0
+            fi
+            git commit -m "Update from ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/attempts/${GITHUB_RUN_ATTEMPT}"
+            git show HEAD --stat
+            if ${{ github.event_name != 'push' && 'true' || 'false' }}; then
+              echo "Not a push event, BRiCk documentation not pushed."
+              exit 0
+            fi
+            if ${{ github.ref_name != github.event.repository.default_branch && 'true' || 'false' }}; then
+              echo "Push to a non-default branch, BRiCk documentation not pushed."
+              exit 0
+            fi
+            git remote set-url origin https://${{ secrets.CI_BRICK_DOCS_TOKEN }}@github.com/SkylabsAI/BRiCk.git
+            if git push; then
+              echo "BRiCk documentation has been pushed."
+              exit 0
+            fi
+            echo "BRiCk documentation push rejected."
+            git checkout main
+            git branch -D gh-pages 2>/dev/null >/dev/null || true
+            let attempt++
+            let seconds=10+$RANDOM%120
+            echo "Sleeping for $seconds seconds."
+            sleep $seconds
+          done
+          echo "BRiCk documentation could not be pushed."
+          exit 1
 
   # Unlike opam-build, this job invokes checkout_workspace twice not once.
   full-build:


### PR DESCRIPTION
This investigates the same approach we had in our GitLab CI (pushing to BRiCk's `gh-pages` branch).

- [x] Prepare the branch 
- [x] Figure out how to push (using a token)
- [x] Only push on push workflows
- [x] Sort out potential concurrency issues: should we just force-push, or retry?