### PR TITLE
build-list: handle aliases properly and add `verbatim` clauses

### DIFF
--- a/dev/build-list/build-list.py
+++ b/dev/build-list/build-list.py
@@ -79,9 +79,9 @@ def make_alias_target(tgt_name, tgts, relative_to):
             tgt = replace_extension(tgt, is_alias=tgt_type in ['@','@@'])
             tgt_rel_path = os.path.relpath(tgt, relative_to)
             if tgt_type == '@':
-                deps.append(node('alias', [tgt_rel_path]))
-            elif tgt_type == '@@':
                 deps.append(node('alias_rec', [tgt_rel_path]))
+            elif tgt_type == '@@':
+                deps.append(node('alias', [tgt_rel_path]))
             elif tgt_type == 'pattern':
                 tgt = os.path.join(tgt, '*')
                 deps.append(node('glob_files_rec', [tgt_rel_path]))


### PR DESCRIPTION
The dune spec for alias targets was fixed:

```
- '@foo/bar'
```

used to produce
```
(alias
  (name "my-target")
  (dep
    (alias "@../foo/bar")))
```
but the name of the alias does not need an `@` sign in a `dep` / `alias` entry. Now, `build-list.py`  produces:

```
(alias
  (name "my-target")
  (dep
    (alias "../foo/bar")))
```

This PR also introduces this syntax:

```
- verbatim: ["a","b","c"]
```

That we can use to produce the following:

```
(alias
  (name "my-target")
  (a b c))
```

when a given construct of `dune` is not supported.