### PR TITLE
Rename [br_timing] profile to [sl_timing].

### DIFF
--- a/dune-workspace
+++ b/dune-workspace
@@ -1,3 +1,3 @@
 (lang dune 3.8)
-(profile br_timing)
+(profile sl_timing)
 (cache enabled)


### PR DESCRIPTION
What is being renamed across repos:
- `bluerock` module path prefix becomes `skylabs`,
- `br_timing` becomes `sl_timing` (dune profile),
- `br_opacity` database becomes `sl_opacity`,
- `db_bluerock*` becomes `db_skylabs`,
- `Set BR ...` becomes `Set SL ...` (Rocq command),
- `br.lock` becomes `sl.lock`,
- `br_modifier` becomes `sl_modifier` (tactic notation),
- ...