### PR TITLE
Separate vendored repos to their own group.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ You can then optionally clone sub-repositories within it.
 ```sh
 make clone -j          # Cloning everything (including private repos).
 make clone-public -j   # Cloning only the publicly-accessible repos.
+make clone-vendored -j # Cloning only the (public) vendored repositories.
 make clone-fmdeps -j   # Cloning (mostly public) repos of fmdeps/.
 make clone-psi -j      # Cloning (private) repos of psi/.
 make clone-bluerock -j # Cloning (private) repos of bluerock/ (used in CI).

--- a/dev/ci/repo-deps.toml
+++ b/dev/ci/repo-deps.toml
@@ -12,7 +12,7 @@
 # path match the associated regular expression. Note that groups should not
 # intersect.
 [ci-groups]
-vendored = "fmdeps/vendored/*"
+vendored = "vendored/*"
 bluerock = "bluerock/*"
 psi = "psi/*"
 

--- a/dev/repos/config.mk
+++ b/dev/repos/config.mk
@@ -36,16 +36,16 @@ REPOS += fmdeps:SkyLabsAI/fm-ci:main:fm-ci/:owned:public
 REPOS += fmdeps:SkyLabsAI/ci:main:ci/:owned:private
 
 # Vendored repositories.
-REPOS += fmdeps:SkyLabsAI/elpi:skylabs-master:vendored/elpi/:upstream:public
-REPOS += fmdeps:SkyLabsAI/rocq-elpi:skylabs-master:vendored/rocq-elpi/:upstream:public
-REPOS += fmdeps:SkyLabsAI/rocq-equations:skylabs-main:vendored/rocq-equations/:upstream:public
-REPOS += fmdeps:SkyLabsAI/rocq-ext-lib:skylabs-master:vendored/rocq-ext-lib/:upstream:public
-REPOS += fmdeps:SkyLabsAI/rocq-iris:skylabs-master:vendored/rocq-iris/:upstream:public
-REPOS += fmdeps:SkyLabsAI/rocq-lsp:skylabs-main:vendored/rocq-lsp/:upstream:public
-REPOS += fmdeps:SkyLabsAI/rocq-stdlib:skylabs-master:vendored/rocq-stdlib/:upstream:public
-REPOS += fmdeps:SkyLabsAI/rocq-stdpp:skylabs-master:vendored/rocq-stdpp/:upstream:public
-REPOS += fmdeps:SkyLabsAI/rocq:skylabs-master:vendored/rocq/:upstream:public
-REPOS += fmdeps:SkyLabsAI/vsrocq:skylabs-main:vendored/vsrocq/:upstream:public
+REPOS += vendored:SkyLabsAI/elpi:skylabs-master:elpi/:upstream:public
+REPOS += vendored:SkyLabsAI/rocq-elpi:skylabs-master:rocq-elpi/:upstream:public
+REPOS += vendored:SkyLabsAI/rocq-equations:skylabs-main:rocq-equations/:upstream:public
+REPOS += vendored:SkyLabsAI/rocq-ext-lib:skylabs-master:rocq-ext-lib/:upstream:public
+REPOS += vendored:SkyLabsAI/rocq-iris:skylabs-master:rocq-iris/:upstream:public
+REPOS += vendored:SkyLabsAI/rocq-lsp:skylabs-main:rocq-lsp/:upstream:public
+REPOS += vendored:SkyLabsAI/rocq-stdlib:skylabs-master:rocq-stdlib/:upstream:public
+REPOS += vendored:SkyLabsAI/rocq-stdpp:skylabs-master:rocq-stdpp/:upstream:public
+REPOS += vendored:SkyLabsAI/rocq:skylabs-master:rocq/:upstream:public
+REPOS += vendored:SkyLabsAI/vsrocq:skylabs-main:vsrocq/:upstream:public
 
 # BlueRock repositories.
 REPOS += bluerock:SkyLabsAI/bluerock.NOVA:skylabs-proof:NOVA/:downstream:private

--- a/fmdeps/.gitignore
+++ b/fmdeps/.gitignore
@@ -7,5 +7,4 @@ fm-ci/
 ci/
 fm-tools/
 skylabs-fm/
-vendored/
 rocq-agent-toolkit/

--- a/vendored/.gitignore
+++ b/vendored/.gitignore
@@ -1,0 +1,10 @@
+elpi/
+rocq/
+rocq-elpi/
+rocq-equations/
+rocq-ext-lib/
+rocq-iris/
+rocq-lsp/
+rocq-stdlib/
+rocq-stdpp/
+vsrocq/


### PR DESCRIPTION
This allows manipulating the vendored repos independently from the fmdeps repos, and also makes grepping in our own code easier.