### PR TITLE
gitignore(workspace): ignore credentials used for docker container access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _build/
 _opam/
 _CoqProject
 .env
+docker/github-login
+docker/github-token


### PR DESCRIPTION
I noticed that these newly-gitignored files were untracked; I don't think we ever want to commit them.