### PR TITLE
[Makefile] add [status]/[status-no-fetch] targets.

### DIFF
--- a/dev/repos/rules.mk
+++ b/dev/repos/rules.mk
@@ -310,6 +310,14 @@ rebase-on-main-workspace:
 .PHONY: rebase-on-main
 rebase-on-main: rebase-on-main-workspace ${REBASE_ON_MAIN_TARGETS}
 
+.PHONY: status
+status:
+	$(Q)$(MAKE) -s loop LOOP_COMMAND=./dev/repos/status.sh FETCH=true
+
+.PHONY: status-no-fetch
+status-no-fetch:
+	$(Q)$(MAKE) -s loop LOOP_COMMAND=./dev/repos/status.sh
+
 # Support for looping over cloned repositories (excluding bhv sub-repos).
 # The LOOP_COMMAND variable must be set for these targets, and the passed
 # command or script will be invoked with the following four arguments:

--- a/dev/repos/status.sh
+++ b/dev/repos/status.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+#
+# This script is meant to be used as a LOOP_COMMAND.
+#
+
+set -euf -o pipefail
+
+if [[ $# -ne 5 ]]; then
+  echo "Error: five command line arguments expected."
+  exit 1
+fi
+
+REPO_PATH="$1"
+REPO_URL="$2"
+REPO_DEFAULT="$3"
+REPO_DIR="$4"
+REPO_MODE="$5"
+
+# Fetch only if requested.
+if [[ "${FETCH:-false}" = "true" ]]; then
+  git -C ${REPO_DIR} fetch --quiet origin
+fi
+
+CUR_BRANCH="$(git -C ${REPO_DIR} branch --show-current)"
+CLEAN="true"
+
+if [[ "${CUR_BRANCH}" = "" ]]; then
+  STATUS="no_branch"
+  CLEAN="false"
+elif [[ "${CUR_BRANCH}" = ${REPO_DEFAULT} ]]; then
+  STATUS="\e[0;32m${CUR_BRANCH}\e[0m"
+  BEHIND=$(git -C ${REPO_DIR} rev-list --count HEAD..origin/${REPO_DEFAULT})
+  AHEAD=$(git -C ${REPO_DIR} rev-list --count origin/${REPO_DEFAULT}..HEAD)
+  if [[ "${BEHIND}" -gt 0 ]]; then
+    STATUS="${STATUS}, \e[0;33mbehind(${BEHIND})\e[0m"
+    CLEAN="false"
+  fi
+  if [[ "${AHEAD}" -gt 0 ]]; then
+    STATUS="${STATUS}, \e[0;33mahead(${AHEAD})\e[0m"
+    CLEAN="false"
+  fi
+  if ! git -C ${REPO_DIR} diff HEAD --quiet; then
+    STATUS="${STATUS}, \e[0;33mdirty\e[0m"
+    CLEAN="false"
+  fi
+  if git -C ${REPO_DIR} status --porcelain | grep -q "^??"; then
+    STATUS="${STATUS}, \e[0;33muntracked_files\e[0m"
+    CLEAN="false"
+  fi
+else
+  CLEAN="false"
+  STATUS="\e[0;33m${CUR_BRANCH}\e[0m"
+  BEHIND=$(git -C ${REPO_DIR} rev-list --count HEAD..origin/${REPO_DEFAULT})
+  if [[ "${BEHIND}" -gt 0 ]]; then
+    STATUS="${STATUS}, \e[0;31mneeds_rebase(${BEHIND})\e[0m"
+  fi
+  if ! git -C ${REPO_DIR} config "branch.${CUR_BRANCH}.remote" > /dev/null; then
+    STATUS="${STATUS}, no_remote"
+  else
+    BEHIND=$(git -C ${REPO_DIR} rev-list --count HEAD..origin/${CUR_BRANCH})
+    AHEAD=$(git -C ${REPO_DIR} rev-list --count origin/${CUR_BRANCH}..HEAD)
+    if [[ "${BEHIND}" -gt 0 ]]; then
+      STATUS="${STATUS}, \e[0;33mbehind(${BEHIND})\e[0m"
+    fi
+    if [[ "${AHEAD}" -gt 0 ]]; then
+      STATUS="${STATUS}, \e[0;33mahead(${AHEAD})\e[0m"
+    fi
+    if ! git -C ${REPO_DIR} diff HEAD --quiet; then
+      STATUS="${STATUS}, \e[0;33mdirty\e[0m"
+    fi
+    if git -C ${REPO_DIR} status --porcelain | grep -q "^??"; then
+      STATUS="${STATUS}, \e[0;33muntracked_files\e[0m"
+    fi
+  fi
+fi
+
+if [[ "${CLEAN}" = "false" ]]; then
+  echo -e "${REPO_DIR}: ${STATUS}"
+fi


### PR DESCRIPTION
This might help some to better understand the status of the workspace.

Not sure if I covered all the cases we want to cover though.

Example output:
```
./: rodolphe/status
fmdeps/skylabs-fm/: rodolphe/test, needs_rebase(2), no_remote
fmdeps/rocq-agent-toolkit/: rodolphe/split-sentence, dirty
psi/data/: main, behind(2)
```