### PR TITLE
Adapt our opam deps to upstream package mutation.

### DIFF
--- a/dev/opam-deps/skylabs-deps.opam
+++ b/dev/opam-deps/skylabs-deps.opam
@@ -43,7 +43,7 @@ depends: [
   "conf-gmp" {= "5"}
   "conf-libffi" {= "2.0.0"}
   "conf-linux-libc-dev" {= "0" & os = "linux"}
-  "conf-pkg-config" {= "4"}
+  "conf-pkg-config" {= "5"}
   "conf-zlib" {= "1"}
   "core" {= "v0.17.2"}
   "core_kernel" {= "v0.17.0"}


### PR DESCRIPTION
Introduced in https://github.com/ocaml/opam-repository/commit/2055acc8858c2c7ec00a67344dea485c98a0e26f.