### PR TITLE
One `.envrc` to rule them all.

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,8 @@
+source_up_if_exists
+
+PATH_add _build/install/default/bin
+PATH_add dev/bin
+
+export OCAMLPATH=$PWD/_build/install/default/lib:$OCAMLPATH
+
+export WORKSPACE=$PWD

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@ _opam/
 .env
 .DS_Store
 **/.DS_Store
-.envrc


### PR DESCRIPTION
Using `source_up_if_exists` will source a `.direnv` from a parent directory, if it exists. So @Janno and people that want to run `eval $(opam env)` or variations thereof can do it there. Personally I don't need it since my shell handles the opam stuff.