### PR TITLE
Add arguments to `make peek` to pass on to `git`

### DIFF
--- a/dev/repos/rules.mk
+++ b/dev/repos/rules.mk
@@ -19,6 +19,8 @@ ifneq ($1,sentinel)
 # Add REPO_GROUP to REPO_GROUPS but without dups
 REPO_GROUPS += $(filter-out ${REPO_GROUPS},${REPO_GROUP})
 
+GIT_PEEK_OPTS ?=
+
 CLONE_TARGETS += clone-${REPO_NAME}
 ${REPO_GROUP}_CLONE_TARGETS += clone-${REPO_NAME}
 ${REPO_VIS}_CLONE_TARGETS += clone-${REPO_NAME}
@@ -140,7 +142,7 @@ peek-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 	@echo ""
 	@echo "Peeking into ${REPO_DIR}:"
-	@git -C ${REPO_DIR} status --short --branch --untracked-files=normal
+	@git -C ${REPO_DIR} status --short --branch --untracked-files=normal ${GIT_PEEK_OPTS}
 else
 	@echo "No repository in ${REPO_DIR}, cannot peek."
 endif
@@ -328,7 +330,7 @@ push: push-workspace ${PUSH_TARGETS}
 peek-workspace:
 	@echo ""
 	@echo "Peeking into ./"
-	@git status --short --branch --untracked-files=normal
+	@git status --short --branch --untracked-files=normal ${GIT_PEEK_OPTS}
 
 .PHONY: peek
 peek: peek-workspace ${PEEK_TARGETS}

--- a/dev/repos/rules.mk
+++ b/dev/repos/rules.mk
@@ -28,6 +28,7 @@ clone-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 	@echo "Repo ${REPO_URL} seems already cloned in ${REPO_DIR}."
 else
+	@echo ""
 	@echo "Cloning ${REPO_URL} in ${REPO_DIR}"
 	$(Q)$${CLONE_ENV_${REPO_NAME}} git clone ${CLONE_ARGS} \
         ${REPO_CLONE_REFERENCE_IF_ABLE} \
@@ -43,6 +44,7 @@ lightweight-clone-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 	@echo "Repo ${REPO_URL} seems already cloned in ${REPO_DIR}."
 else
+	@echo ""
 	@echo "Cloning ${REPO_URL} in ${REPO_DIR} (lightweight, no checkout)"
 	$(Q)$${CLONE_ENV_${REPO_NAME}} git clone ${CLONE_ARGS} \
         ${REPO_CLONE_REFERENCE_IF_ABLE} \
@@ -88,6 +90,7 @@ ${REPO_MODE}_FETCH_TARGETS += fetch-${REPO_NAME}
 .PHONY: fetch-${REPO_NAME}
 fetch-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
+	@echo ""
 	@echo "Fetching in ${REPO_DIR}."
 	$(Q)git -C ${REPO_DIR} fetch --all --quiet
 else
@@ -101,6 +104,7 @@ ${REPO_MODE}_PULL_TARGETS += pull-${REPO_NAME}
 .PHONY: pull-${REPO_NAME}
 pull-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
+	@echo ""
 	@echo "Pulling in ${REPO_DIR}."
 	$(Q)git -C ${REPO_DIR} pull --rebase
 else
@@ -115,9 +119,11 @@ ${REPO_MODE}_PUSH_TARGETS += push-${REPO_NAME}
 push-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 ifeq (${PUSH_ARGS},)
+	@echo ""
 	@echo "Pushing in ${REPO_DIR}."
 	$(Q)git -C ${REPO_DIR} push
 else
+	@echo ""
 	@echo "Pushing in ${REPO_DIR} (${PUSH_ARGS})."
 	$(Q)git -C ${REPO_DIR} push ${PUSH_ARGS}
 endif
@@ -132,6 +138,7 @@ ${REPO_MODE}_PEEK_TARGETS += peek-${REPO_NAME}
 .PHONY: peek-${REPO_NAME}
 peek-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
+	@echo ""
 	@echo "Peeking into ${REPO_DIR}:"
 	@git -C ${REPO_DIR} status --short --branch --untracked-files=normal
 else
@@ -145,6 +152,7 @@ ${REPO_MODE}_GITCLEAN_TARGETS += gitclean-${REPO_NAME}
 .PHONY: gitclean-${REPO_NAME}
 gitclean-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
+	@echo ""
 	@echo "Cleaning ${REPO_DIR}:"
 	$(Q)git -C ${REPO_DIR} clean -xfd
 else
@@ -168,6 +176,7 @@ ${REPO_MODE}_CHECKOUT_MAIN_TARGETS += checkout-main-${REPO_NAME}
 .PHONY: checkout-main-${REPO_NAME}
 checkout-main-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
+	@echo ""
 	@echo "Checking out branch ${REPO_DEFAULT} in ${REPO_DIR}:"
 	$(Q)git -C ${REPO_DIR} checkout ${REPO_DEFAULT}
 else
@@ -181,6 +190,7 @@ ${REPO_MODE}_REBASE_ON_MAIN_TARGETS += rebase-on-main-${REPO_NAME}
 .PHONY: rebase-on-main-${REPO_NAME}
 rebase-on-main-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
+	@echo ""
 	@echo "Rebasing on origin/${REPO_DEFAULT} in ${REPO_DIR}:"
 	$(Q)git -C ${REPO_DIR} rebase origin/${REPO_DEFAULT}
 else
@@ -197,6 +207,7 @@ ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 ifeq (${TAG_ARGS},)
 	@echo "Variable TAG_ARGS not set, not tagging ${REPO_DIR}."
 else
+	@echo ""
 	@echo "Tagging ${REPO_DIR} (${TAG_ARGS}):"
 	$(Q)git -C ${REPO_DIR} tag ${TAG_ARGS}
 endif
@@ -287,6 +298,7 @@ describe: describe-workspace ${DESCRIBE_TARGETS}
 
 .PHONY: fetch-workspace
 fetch-workspace:
+	@echo ""
 	@echo "Fetching at the workspace root."
 	$(Q)git fetch --all --quiet
 
@@ -295,6 +307,7 @@ fetch: fetch-workspace ${FETCH_TARGETS}
 
 .PHONY: pull-workspace
 pull-workspace:
+	@echo ""
 	@echo "Pulling at the workspace root."
 	$(Q)git pull --rebase
 
@@ -304,6 +317,7 @@ pull: pull-workspace
 
 .PHONY: push-workspace
 push-workspace:
+	@echo ""
 	@echo "Pushing at the workspace root."
 	$(Q)git push
 
@@ -312,6 +326,7 @@ push: push-workspace ${PUSH_TARGETS}
 
 .PHONY: peek-workspace
 peek-workspace:
+	@echo ""
 	@echo "Peeking into ./"
 	@git status --short --branch --untracked-files=normal
 
@@ -320,6 +335,7 @@ peek: peek-workspace ${PEEK_TARGETS}
 
 .PHONY: gitclean-workspace
 gitclean-workspace:
+	@echo ""
 	@echo "Cleaning ./:"
 	$(Q)git clean -xfd
 
@@ -335,6 +351,7 @@ ls-files: ls-files-workspace ${LS_FILES_TARGETS}
 
 .PHONY: checkout-main-workspace
 checkout-main-workspace:
+	@echo ""
 	@echo "Checking out branch main in ./:"
 	$(Q)git checkout main
 
@@ -343,6 +360,7 @@ checkout-main: checkout-main-workspace ${CHECKOUT_MAIN_TARGETS}
 
 .PHONY: rebase-on-main-workspace
 rebase-on-main-workspace:
+	@echo ""
 	@echo "Rebasing on origin/main in ./:"
 	$(Q)git rebase origin/main
 
@@ -354,6 +372,7 @@ tag-workspace:
 ifeq (${TAG_ARGS},)
 	@echo "Variable TAG_ARGS not set, not tagging ./."
 else
+	@echo ""
 	@echo "Tagging ./ (${TAG_ARGS}):"
 	$(Q)git tag ${TAG_ARGS}
 endif


### PR DESCRIPTION
This give the user the ability to call `make GIT_PEEK_OPTS=-uno peek` if the user wants to hide untracked files.

This PR also adds spacing between the output of git coming from separate repos for clarity.