### PR TITLE
Makefile/repos: new formatting options, make commit, make checkout

### DIFF
--- a/dev/format.sh
+++ b/dev/format.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+INDENT="no"
+QUIET="no"
+SKIP_FIRST_LINE="no"
+CMD=""
+PROG=""
+
+usage () {
+    cat <<EOF
+usage:
+  $0 run [--indent] [--quiet] [--skip-first-line] [--heading=HEADING] --
+         PROGRAM [ARGS ..]
+  $0 eval [--indent] [--quiet] [--skip-first-line] [--heading=HEADING] --
+         SHELL_COMMAND
+
+Call SHELL_COMMAND ARGS and add some formatting elements such as
+spacing, indentation and heading to the output of said command.
+
+  --indent
+    Prefix each line of output of SHELL_COMMAND with two spaces.
+
+  --quiet
+    Prefix each line of output of SHELL_COMMAND with two spaces.
+
+  --skip-first-line
+    Start output with blank line.
+
+  --heading=HEADING
+    Output HEADING on its own line before calling SHELL_COMMAND. HEADING
+    is not affected by --indent.
+
+  PROGRAM [ARGS ..]
+    A program and its arguments; it will be run by $0. If the
+    command is prefixed by '@', it is the equivalent to flag --quiet.
+
+  SHELL_COMMAND
+    A single argument comprising a complete shell command to be run
+    verbatim.
+EOF
+}
+
+yes_no () {
+    if [[ $1 =~ --no-.* ]]; then
+        echo "no"
+    else
+        echo "yes"
+    fi
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --indent|--no-indent)
+            INDENT="$(yes_no $1)" ;;
+        --quiet|--no-quiet)
+            QUIET="$(yes_no $1)" ;;
+        --skip-first-line|--no-skip-first-line)
+            SKIP_FIRST_LINE="$(yes_no $1)" ;;
+        --heading=*)
+            [[ $1 =~ --heading=(.*) ]]
+            HEADING="${BASH_REMATCH[1]}" ;;
+        run|eval)
+            CMD="$1" ;;
+        --)
+            shift
+            PROG="$1"
+            if [[ $PROG =~ @.* ]]; then
+                PROG="${PROG/#@/}"
+                QUIET=yes
+            fi
+            shift
+            break ;;
+        *)
+            echo "Invalid argument $HD"
+            usage
+            exit -1
+    esac
+    shift
+done
+
+do_run () {
+    local cmd="$1" ; shift ;
+    if [[ $QUIET == "no" ]]; then
+        echo "$cmd ${*@Q}" # only works on Bash 4.4
+    fi
+    if [[ "$INDENT" == "no" ]]; then
+        "$cmd" "$@"
+    else
+        "$cmd" "$@" | gsed "s/^/  /"; test ${PIPESTATUS[0]} -eq 0
+    fi
+}
+
+do_eval () {
+    if [[ $QUIET == "no" ]]; then
+        echo "${*@Q}" # only works on Bash 4.4
+    fi
+    if [[ "$INDENT" == "no" ]]; then
+        eval "$@"
+    else
+        eval "$@" | gsed "s/^/  /"; test ${PIPESTATUS[0]} -eq 0
+    fi
+}
+
+if [[ "$CMD" =~ run|eval ]]; then
+    if [[ "$SKIP_FIRST_LINE" == yes ]]; then
+        echo
+    fi
+    if [[ -n "$HEADING" ]]; then
+        echo "$HEADING"
+    fi
+    if [[ "$CMD" == run ]]; then
+        do_run "$PROG" "$@"
+    else
+        do_eval "$PROG" "$@"
+    fi
+else
+    echo "Invalid command: $CMD"
+    exit -1
+fi

--- a/dev/repos/rules.mk
+++ b/dev/repos/rules.mk
@@ -186,6 +186,22 @@ else
 	@echo "No repository in ${REPO_DIR}, cannot checkout."
 endif
 
+CHECKOUT_BRANCH_TARGETS += checkout-branch-${REPO_NAME}
+${REPO_GROUP}_CHECKOUT_BRANCH_TARGETS += checkout-branch-${REPO_NAME}
+${REPO_VIS}_CHECKOUT_BRANCH_TARGETS += checkout-branch-${REPO_NAME}
+${REPO_MODE}_CHECKOUT_BRANCH_TARGETS += checkout-branch-${REPO_NAME}
+.PHONY: checkout-branch-${REPO_NAME}
+checkout-branch-${REPO_NAME}:
+ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
+	@dev/format.sh ${GIT_FORMATTING} eval \
+		--heading="Checking out branch ${SELECT_BRANCH} in ${REPO_DIR}:" -- \
+		"$(Q)git -C ${REPO_DIR} checkout ${SELECT_BRANCH} || \
+			git -C ${REPO_DIR} checkout -b ${SELECT_BRANCH} origin/${REPO_DEFAULT} || \
+			git -C ${REPO_DIR} checkout -b ${SELECT_BRANCH} HEAD --track=inherit"
+else
+	@echo "No repository in ${REPO_DIR}, cannot checkout."
+endif
+
 REBASE_ON_MAIN_TARGETS += rebase-on-main-${REPO_NAME}
 ${REPO_GROUP}_REBASE_ON_MAIN_TARGETS += rebase-on-main-${REPO_NAME}
 ${REPO_VIS}_REBASE_ON_MAIN_TARGETS += rebase-on-main-${REPO_NAME}
@@ -362,6 +378,17 @@ checkout-main-workspace:
 
 .PHONY: checkout-main
 checkout-main: checkout-main-workspace ${CHECKOUT_MAIN_TARGETS}
+
+.PHONY: checkout-branch-workspace
+checkout-branch-workspace:
+	@dev/format.sh ${GIT_FORMATTING} eval \
+		--heading="Checking out ${SELECT_BRANCH} main in ./:" -- \
+		"$(Q)git checkout ${SELECT_BRANCH} || \
+			git checkout -b ${SELECT_BRANCH} origin/main || \
+			git checkout -b ${SELECT_BRANCH} HEAD --track=inherit ${GIT_PEEK_OPTS}"
+
+.PHONY: checkout
+checkout: checkout-branch-workspace ${CHECKOUT_BRANCH_TARGETS}
 
 .PHONY: rebase-on-main-workspace
 rebase-on-main-workspace:

--- a/dev/repos/rules.mk
+++ b/dev/repos/rules.mk
@@ -202,6 +202,24 @@ else
 	@echo "No repository in ${REPO_DIR}, cannot checkout."
 endif
 
+COMMIT_TARGETS += commit-${REPO_NAME}
+${REPO_GROUP}_COMMIT_TARGETS += commit-${REPO_NAME}
+${REPO_VIS}_COMMIT_TARGETS += commit-${REPO_NAME}
+${REPO_MODE}_COMMIT_TARGETS += commit-${REPO_NAME}
+.PHONY: commit-${REPO_NAME}
+commit-${REPO_NAME}:
+ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
+	echo "${REPO_DIR}"
+	$(eval CURRENT_BRANCH := $$(shell git -C ${REPO_DIR} branch --show-current))
+	@dev/format.sh --indent --skip-first-line run \
+		--heading="Commit to $(CURRENT_BRANCH) in ${REPO_DIR}:" -- \
+		$(Q)git -C ${REPO_DIR} commit -m "${COMMIT_MESSAGE}" -a ${GIT_PEEK_OPTS} \
+		|| true
+else
+	@echo "No repository in ${REPO_DIR}, cannot commit."
+endif
+
+
 REBASE_ON_MAIN_TARGETS += rebase-on-main-${REPO_NAME}
 ${REPO_GROUP}_REBASE_ON_MAIN_TARGETS += rebase-on-main-${REPO_NAME}
 ${REPO_VIS}_REBASE_ON_MAIN_TARGETS += rebase-on-main-${REPO_NAME}
@@ -389,6 +407,15 @@ checkout-branch-workspace:
 
 .PHONY: checkout
 checkout: checkout-branch-workspace ${CHECKOUT_BRANCH_TARGETS}
+
+.PHONY: commit-workspace commit
+commit-workspace:
+	echo "workspace"
+	$(eval CURRENT_BRANCH := $$(shell git branch --show-current))
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Commit to $(CURRENT_BRANCH) in ./:" -- \
+		$(Q)git commit -m "${COMMIT_MESSAGE}" -a ${GIT_PEEK_OPTS} || true
+commit: commit-workspace ${COMMIT_TARGETS}
 
 .PHONY: rebase-on-main-workspace
 rebase-on-main-workspace:

--- a/dev/repos/rules.mk
+++ b/dev/repos/rules.mk
@@ -1,5 +1,7 @@
 include dev/repos/config.mk
 
+QFORMAT=@
+
 REPO_GROUPS = upstream owned downstream public private
 
 define subrepo_targets
@@ -34,7 +36,7 @@ clone-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 	@echo "Repo ${REPO_URL} seems already cloned in ${REPO_DIR}."
 else
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Cloning ${REPO_URL} in ${REPO_DIR}" -- \
 		$(Q)$${CLONE_ENV_${REPO_NAME}} git clone ${CLONE_ARGS} \
 		${REPO_CLONE_REFERENCE_IF_ABLE} \
@@ -50,7 +52,7 @@ lightweight-clone-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 	@echo "Repo ${REPO_URL} seems already cloned in ${REPO_DIR}."
 else
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Cloning ${REPO_URL} in ${REPO_DIR} (lightweight, no checkout)" -- \
 		$(Q)$${CLONE_ENV_${REPO_NAME}} git clone ${CLONE_ARGS} \
 	        ${REPO_CLONE_REFERENCE_IF_ABLE} \
@@ -109,7 +111,7 @@ ${REPO_MODE}_PULL_TARGETS += pull-${REPO_NAME}
 .PHONY: pull-${REPO_NAME}
 pull-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Pulling in ${REPO_DIR}." -- \
 		$(Q)git -C ${REPO_DIR} pull --rebase
 else
@@ -124,11 +126,11 @@ ${REPO_MODE}_PUSH_TARGETS += push-${REPO_NAME}
 push-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 ifeq (${PUSH_ARGS},)
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Pushing in ${REPO_DIR}." -- \
 		$(Q)git -C ${REPO_DIR} push
 else
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Pushing in ${REPO_DIR} (${PUSH_ARGS})." -- \
 		$(Q)git -C ${REPO_DIR} push ${PUSH_ARGS}
 endif
@@ -143,7 +145,7 @@ ${REPO_MODE}_PEEK_TARGETS += peek-${REPO_NAME}
 .PHONY: peek-${REPO_NAME}
 peek-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Peeking into ${REPO_DIR}:" -- \
 		@git -C ${REPO_DIR} status --short --branch --untracked-files=normal ${GIT_OPTS}
 else
@@ -158,11 +160,11 @@ ${REPO_MODE}_GITCLEAN_TARGETS += gitclean-${REPO_NAME}
 gitclean-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 ifeq (${GITCLEAN_DRY_RUN},no)
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Cleaning ${REPO_DIR}:" -- \
 		$(Q)git -C ${REPO_DIR} clean -xfd
 else
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Cleaning ${REPO_DIR} (dry run):" -- \
 		$(Q)git -C ${REPO_DIR} clean -nxfd
 endif
@@ -187,7 +189,7 @@ ${REPO_MODE}_CHECKOUT_MAIN_TARGETS += checkout-main-${REPO_NAME}
 .PHONY: checkout-main-${REPO_NAME}
 checkout-main-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Checking out branch ${REPO_DEFAULT} in ${REPO_DIR}:" -- \
 		$(Q)git -C ${REPO_DIR} checkout ${REPO_DEFAULT}
 else
@@ -201,7 +203,7 @@ ${REPO_MODE}_CHECKOUT_BRANCH_TARGETS += checkout-branch-${REPO_NAME}
 .PHONY: checkout-branch-${REPO_NAME}
 checkout-branch-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	@dev/format.sh ${GIT_FORMATTING} eval \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} eval \
 		--heading="Checking out branch ${SELECT_BRANCH} in ${REPO_DIR}:" -- \
 		"$(Q)git -C ${REPO_DIR} checkout ${SELECT_BRANCH} || \
 			git -C ${REPO_DIR} checkout -b ${SELECT_BRANCH} origin/${REPO_DEFAULT} || \
@@ -219,7 +221,7 @@ commit-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 	echo "${REPO_DIR}"
 	$$(eval CURRENT_BRANCH := $$(shell git -C ${REPO_DIR} branch --show-current))
-	@dev/format.sh --indent --skip-first-line run \
+	$(QFORMAT)dev/format.sh --indent --skip-first-line run \
 		--heading="Commit to $(CURRENT_BRANCH) in ${REPO_DIR}:" -- \
 		$(Q)git -C ${REPO_DIR} commit -m "${COMMIT_MESSAGE}" -a ${GIT_OPTS} \
 		|| true
@@ -235,7 +237,7 @@ ${REPO_MODE}_REBASE_ON_MAIN_TARGETS += rebase-on-main-${REPO_NAME}
 .PHONY: rebase-on-main-${REPO_NAME}
 rebase-on-main-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Rebasing on origin/${REPO_DEFAULT} in ${REPO_DIR}:" -- \
 		$(Q)git -C ${REPO_DIR} rebase origin/${REPO_DEFAULT}
 else
@@ -252,7 +254,7 @@ ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 ifeq (${TAG_ARGS},)
 	@echo "Variable TAG_ARGS not set, not tagging ${REPO_DIR}."
 else
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Tagging ${REPO_DIR} (${TAG_ARGS}):" -- \
 		$(Q)git -C ${REPO_DIR} tag ${TAG_ARGS}
 endif
@@ -335,9 +337,9 @@ show-config: show-config-workspace $(SHOW_CONFIG_TARGETS)
 
 .PHONY: describe-workspace
 describe-workspace:
-	@dev/format.sh ${GIT_FORMATTING} run -- \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run -- \
 		@git log --pretty=tformat:'./: %H' -n 1
-	@dev/format.sh ${GIT_FORMATTING} --no-skip-first-line eval -- \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} --no-skip-first-line eval -- \
 		'@git diff HEAD --quiet || echo "./ is dirty"'
 
 .PHONY: describe
@@ -345,7 +347,7 @@ describe: describe-workspace ${DESCRIBE_TARGETS}
 
 .PHONY: fetch-workspace
 fetch-workspace:
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Fetching at the workspace root." -- \
 		$(Q)git fetch --all --quiet
 
@@ -354,7 +356,7 @@ fetch: fetch-workspace ${FETCH_TARGETS}
 
 .PHONY: pull-workspace
 pull-workspace:
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Pulling at the workspace root." -- \
 		$(Q)git pull --rebase
 
@@ -364,7 +366,7 @@ pull: pull-workspace
 
 .PHONY: push-workspace
 push-workspace:
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Pushing at the workspace root." -- \
 		$(Q)git push
 
@@ -373,7 +375,7 @@ push: push-workspace ${PUSH_TARGETS}
 
 .PHONY: peek-workspace
 peek-workspace:
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Peeking into ./" -- \
 		@git status --short --branch --untracked-files=normal ${GIT_OPTS}
 
@@ -383,11 +385,11 @@ peek: peek-workspace ${PEEK_TARGETS}
 .PHONY: gitclean-workspace
 gitclean-workspace:
 ifeq (${GITCLEAN_DRY_RUN},no)
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Cleaning ./:" -- \
 		$(Q)git clean -xfd
 else
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Cleaning ./ (dry run, use GITCLEAN_DRY_RUN=no to disable):" -- \
 		$(Q)git clean -nxfd
 endif
@@ -404,7 +406,7 @@ ls-files: ls-files-workspace ${LS_FILES_TARGETS}
 
 .PHONY: checkout-main-workspace
 checkout-main-workspace:
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Checking out branch main in ./:" -- \
 		$(Q)git checkout main
 
@@ -413,7 +415,7 @@ checkout-main: checkout-main-workspace ${CHECKOUT_MAIN_TARGETS}
 
 .PHONY: checkout-branch-workspace
 checkout-branch-workspace:
-	@dev/format.sh ${GIT_FORMATTING} eval \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} eval \
 		--heading="Checking out ${SELECT_BRANCH} main in ./:" -- \
 		"$(Q)git checkout ${SELECT_BRANCH} || \
 			git checkout -b ${SELECT_BRANCH} origin/main || \
@@ -426,14 +428,14 @@ checkout: checkout-branch-workspace ${CHECKOUT_BRANCH_TARGETS}
 commit-workspace:
 	echo "workspace"
 	$$(eval CURRENT_BRANCH := $$(shell git branch --show-current))
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Commit to $(CURRENT_BRANCH) in ./:" -- \
 		$(Q)git commit -m "${COMMIT_MESSAGE}" -a ${GIT_OPTS} || true
 commit: commit-workspace ${COMMIT_TARGETS}
 
 .PHONY: rebase-on-main-workspace
 rebase-on-main-workspace:
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Rebasing on origin/main in ./:" -- \
 		$(Q)git rebase origin/main
 
@@ -445,7 +447,7 @@ tag-workspace:
 ifeq (${TAG_ARGS},)
 	@echo "Variable TAG_ARGS not set, not tagging ./."
 else
-	@dev/format.sh ${GIT_FORMATTING} run \
+	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Tagging ./ (${TAG_ARGS}):" -- \
 		$(Q)git tag ${TAG_ARGS}
 endif

--- a/dev/repos/rules.mk
+++ b/dev/repos/rules.mk
@@ -219,10 +219,8 @@ ${REPO_MODE}_COMMIT_TARGETS += commit-${REPO_NAME}
 .PHONY: commit-${REPO_NAME}
 commit-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	echo "${REPO_DIR}"
-	$$(eval CURRENT_BRANCH := $$(shell git -C ${REPO_DIR} branch --show-current))
 	$(QFORMAT)dev/format.sh --indent --skip-first-line run \
-		--heading="Commit to $(CURRENT_BRANCH) in ${REPO_DIR}:" -- \
+		--heading="Commit in ${REPO_DIR}:" -- \
 		$(Q)git -C ${REPO_DIR} commit -m "${COMMIT_MESSAGE}" -a ${GIT_OPTS} \
 		|| true
 else
@@ -426,8 +424,6 @@ checkout: checkout-branch-workspace ${CHECKOUT_BRANCH_TARGETS}
 
 .PHONY: commit-workspace commit
 commit-workspace:
-	echo "workspace"
-	$$(eval CURRENT_BRANCH := $$(shell git branch --show-current))
 	$(QFORMAT)dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Commit to $(CURRENT_BRANCH) in ./:" -- \
 		$(Q)git commit -m "${COMMIT_MESSAGE}" -a ${GIT_OPTS} || true

--- a/dev/repos/rules.mk
+++ b/dev/repos/rules.mk
@@ -19,7 +19,7 @@ ifneq ($1,sentinel)
 # Add REPO_GROUP to REPO_GROUPS but without dups
 REPO_GROUPS += $(filter-out ${REPO_GROUPS},${REPO_GROUP})
 
-GIT_PEEK_OPTS ?=
+GIT_OPTS ?=
 
 GIT_FORMATTING ?= --skip-first-line --indent
 
@@ -143,7 +143,7 @@ peek-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 	@dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Peeking into ${REPO_DIR}:" -- \
-		@git -C ${REPO_DIR} status --short --branch --untracked-files=normal ${GIT_PEEK_OPTS}
+		@git -C ${REPO_DIR} status --short --branch --untracked-files=normal ${GIT_OPTS}
 else
 	@echo "No repository in ${REPO_DIR}, cannot peek."
 endif
@@ -213,7 +213,7 @@ ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 	$(eval CURRENT_BRANCH := $$(shell git -C ${REPO_DIR} branch --show-current))
 	@dev/format.sh --indent --skip-first-line run \
 		--heading="Commit to $(CURRENT_BRANCH) in ${REPO_DIR}:" -- \
-		$(Q)git -C ${REPO_DIR} commit -m "${COMMIT_MESSAGE}" -a ${GIT_PEEK_OPTS} \
+		$(Q)git -C ${REPO_DIR} commit -m "${COMMIT_MESSAGE}" -a ${GIT_OPTS} \
 		|| true
 else
 	@echo "No repository in ${REPO_DIR}, cannot commit."
@@ -367,7 +367,7 @@ push: push-workspace ${PUSH_TARGETS}
 peek-workspace:
 	@dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Peeking into ./" -- \
-		@git status --short --branch --untracked-files=normal ${GIT_PEEK_OPTS}
+		@git status --short --branch --untracked-files=normal ${GIT_OPTS}
 
 .PHONY: peek
 peek: peek-workspace ${PEEK_TARGETS}
@@ -403,7 +403,7 @@ checkout-branch-workspace:
 		--heading="Checking out ${SELECT_BRANCH} main in ./:" -- \
 		"$(Q)git checkout ${SELECT_BRANCH} || \
 			git checkout -b ${SELECT_BRANCH} origin/main || \
-			git checkout -b ${SELECT_BRANCH} HEAD --track=inherit ${GIT_PEEK_OPTS}"
+			git checkout -b ${SELECT_BRANCH} HEAD --track=inherit ${GIT_OPTS}"
 
 .PHONY: checkout
 checkout: checkout-branch-workspace ${CHECKOUT_BRANCH_TARGETS}
@@ -414,7 +414,7 @@ commit-workspace:
 	$(eval CURRENT_BRANCH := $$(shell git branch --show-current))
 	@dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Commit to $(CURRENT_BRANCH) in ./:" -- \
-		$(Q)git commit -m "${COMMIT_MESSAGE}" -a ${GIT_PEEK_OPTS} || true
+		$(Q)git commit -m "${COMMIT_MESSAGE}" -a ${GIT_OPTS} || true
 commit: commit-workspace ${COMMIT_TARGETS}
 
 .PHONY: rebase-on-main-workspace

--- a/dev/repos/rules.mk
+++ b/dev/repos/rules.mk
@@ -210,7 +210,7 @@ ${REPO_MODE}_COMMIT_TARGETS += commit-${REPO_NAME}
 commit-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 	echo "${REPO_DIR}"
-	$(eval CURRENT_BRANCH := $$(shell git -C ${REPO_DIR} branch --show-current))
+	$$(eval CURRENT_BRANCH := $$(shell git -C ${REPO_DIR} branch --show-current))
 	@dev/format.sh --indent --skip-first-line run \
 		--heading="Commit to $(CURRENT_BRANCH) in ${REPO_DIR}:" -- \
 		$(Q)git -C ${REPO_DIR} commit -m "${COMMIT_MESSAGE}" -a ${GIT_OPTS} \
@@ -411,7 +411,7 @@ checkout: checkout-branch-workspace ${CHECKOUT_BRANCH_TARGETS}
 .PHONY: commit-workspace commit
 commit-workspace:
 	echo "workspace"
-	$(eval CURRENT_BRANCH := $$(shell git branch --show-current))
+	$$(eval CURRENT_BRANCH := $$(shell git branch --show-current))
 	@dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Commit to $(CURRENT_BRANCH) in ./:" -- \
 		$(Q)git commit -m "${COMMIT_MESSAGE}" -a ${GIT_OPTS} || true

--- a/dev/repos/rules.mk
+++ b/dev/repos/rules.mk
@@ -23,6 +23,8 @@ GIT_OPTS ?=
 
 GIT_FORMATTING ?= --skip-first-line --indent
 
+GITCLEAN_DRY_RUN ?= yes
+
 CLONE_TARGETS += clone-${REPO_NAME}
 ${REPO_GROUP}_CLONE_TARGETS += clone-${REPO_NAME}
 ${REPO_VIS}_CLONE_TARGETS += clone-${REPO_NAME}
@@ -155,9 +157,15 @@ ${REPO_MODE}_GITCLEAN_TARGETS += gitclean-${REPO_NAME}
 .PHONY: gitclean-${REPO_NAME}
 gitclean-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
+ifeq (${GITCLEAN_DRY_RUN},no)
 	@dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Cleaning ${REPO_DIR}:" -- \
 		$(Q)git -C ${REPO_DIR} clean -xfd
+else
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Cleaning ${REPO_DIR} (dry run):" -- \
+		$(Q)git -C ${REPO_DIR} clean -nxfd
+endif
 else
 	@echo "No repository in ${REPO_DIR}, cannot clean."
 endif
@@ -374,9 +382,15 @@ peek: peek-workspace ${PEEK_TARGETS}
 
 .PHONY: gitclean-workspace
 gitclean-workspace:
+ifeq (${GITCLEAN_DRY_RUN},no)
 	@dev/format.sh ${GIT_FORMATTING} run \
 		--heading="Cleaning ./:" -- \
 		$(Q)git clean -xfd
+else
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Cleaning ./ (dry run, use GITCLEAN_DRY_RUN=no to disable):" -- \
+		$(Q)git clean -nxfd
+endif
 
 .PHONY: gitclean
 gitclean: gitclean-workspace ${GITCLEAN_TARGETS}

--- a/dev/repos/rules.mk
+++ b/dev/repos/rules.mk
@@ -21,6 +21,8 @@ REPO_GROUPS += $(filter-out ${REPO_GROUPS},${REPO_GROUP})
 
 GIT_PEEK_OPTS ?=
 
+GIT_FORMATTING ?= --skip-first-line --indent
+
 CLONE_TARGETS += clone-${REPO_NAME}
 ${REPO_GROUP}_CLONE_TARGETS += clone-${REPO_NAME}
 ${REPO_VIS}_CLONE_TARGETS += clone-${REPO_NAME}
@@ -30,11 +32,11 @@ clone-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 	@echo "Repo ${REPO_URL} seems already cloned in ${REPO_DIR}."
 else
-	@echo ""
-	@echo "Cloning ${REPO_URL} in ${REPO_DIR}"
-	$(Q)$${CLONE_ENV_${REPO_NAME}} git clone ${CLONE_ARGS} \
-        ${REPO_CLONE_REFERENCE_IF_ABLE} \
-		--branch ${REPO_DEFAULT} ${REPO_URL} ${REPO_DIR}
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Cloning ${REPO_URL} in ${REPO_DIR}" -- \
+		$(Q)$${CLONE_ENV_${REPO_NAME}} git clone ${CLONE_ARGS} \
+		${REPO_CLONE_REFERENCE_IF_ABLE} \
+			--branch ${REPO_DEFAULT} ${REPO_URL} ${REPO_DIR}
 endif
 
 LIGHTWEIGHT_CLONE_TARGETS += lightweight-clone-${REPO_NAME}
@@ -46,11 +48,11 @@ lightweight-clone-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 	@echo "Repo ${REPO_URL} seems already cloned in ${REPO_DIR}."
 else
-	@echo ""
-	@echo "Cloning ${REPO_URL} in ${REPO_DIR} (lightweight, no checkout)"
-	$(Q)$${CLONE_ENV_${REPO_NAME}} git clone ${CLONE_ARGS} \
-        ${REPO_CLONE_REFERENCE_IF_ABLE} \
-		--no-checkout --filter=tree:0 --quiet ${REPO_URL} ${REPO_DIR}
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Cloning ${REPO_URL} in ${REPO_DIR} (lightweight, no checkout)" -- \
+		$(Q)$${CLONE_ENV_${REPO_NAME}} git clone ${CLONE_ARGS} \
+	        ${REPO_CLONE_REFERENCE_IF_ABLE} \
+			--no-checkout --filter=tree:0 --quiet ${REPO_URL} ${REPO_DIR}
 endif
 
 NUKE_TARGETS += nuke-${REPO_NAME}
@@ -92,7 +94,6 @@ ${REPO_MODE}_FETCH_TARGETS += fetch-${REPO_NAME}
 .PHONY: fetch-${REPO_NAME}
 fetch-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	@echo ""
 	@echo "Fetching in ${REPO_DIR}."
 	$(Q)git -C ${REPO_DIR} fetch --all --quiet
 else
@@ -106,9 +107,9 @@ ${REPO_MODE}_PULL_TARGETS += pull-${REPO_NAME}
 .PHONY: pull-${REPO_NAME}
 pull-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	@echo ""
-	@echo "Pulling in ${REPO_DIR}."
-	$(Q)git -C ${REPO_DIR} pull --rebase
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Pulling in ${REPO_DIR}." -- \
+		$(Q)git -C ${REPO_DIR} pull --rebase
 else
 	@echo "No repository in ${REPO_DIR}, cannot pull."
 endif
@@ -121,13 +122,13 @@ ${REPO_MODE}_PUSH_TARGETS += push-${REPO_NAME}
 push-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 ifeq (${PUSH_ARGS},)
-	@echo ""
-	@echo "Pushing in ${REPO_DIR}."
-	$(Q)git -C ${REPO_DIR} push
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Pushing in ${REPO_DIR}." -- \
+		$(Q)git -C ${REPO_DIR} push
 else
-	@echo ""
-	@echo "Pushing in ${REPO_DIR} (${PUSH_ARGS})."
-	$(Q)git -C ${REPO_DIR} push ${PUSH_ARGS}
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Pushing in ${REPO_DIR} (${PUSH_ARGS})." -- \
+		$(Q)git -C ${REPO_DIR} push ${PUSH_ARGS}
 endif
 else
 	@echo "No repository in ${REPO_DIR}, cannot push."
@@ -140,9 +141,9 @@ ${REPO_MODE}_PEEK_TARGETS += peek-${REPO_NAME}
 .PHONY: peek-${REPO_NAME}
 peek-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	@echo ""
-	@echo "Peeking into ${REPO_DIR}:"
-	@git -C ${REPO_DIR} status --short --branch --untracked-files=normal ${GIT_PEEK_OPTS}
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Peeking into ${REPO_DIR}:" -- \
+		@git -C ${REPO_DIR} status --short --branch --untracked-files=normal ${GIT_PEEK_OPTS}
 else
 	@echo "No repository in ${REPO_DIR}, cannot peek."
 endif
@@ -154,9 +155,9 @@ ${REPO_MODE}_GITCLEAN_TARGETS += gitclean-${REPO_NAME}
 .PHONY: gitclean-${REPO_NAME}
 gitclean-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	@echo ""
-	@echo "Cleaning ${REPO_DIR}:"
-	$(Q)git -C ${REPO_DIR} clean -xfd
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Cleaning ${REPO_DIR}:" -- \
+		$(Q)git -C ${REPO_DIR} clean -xfd
 else
 	@echo "No repository in ${REPO_DIR}, cannot clean."
 endif
@@ -178,9 +179,9 @@ ${REPO_MODE}_CHECKOUT_MAIN_TARGETS += checkout-main-${REPO_NAME}
 .PHONY: checkout-main-${REPO_NAME}
 checkout-main-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	@echo ""
-	@echo "Checking out branch ${REPO_DEFAULT} in ${REPO_DIR}:"
-	$(Q)git -C ${REPO_DIR} checkout ${REPO_DEFAULT}
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Checking out branch ${REPO_DEFAULT} in ${REPO_DIR}:" -- \
+		$(Q)git -C ${REPO_DIR} checkout ${REPO_DEFAULT}
 else
 	@echo "No repository in ${REPO_DIR}, cannot checkout."
 endif
@@ -192,9 +193,9 @@ ${REPO_MODE}_REBASE_ON_MAIN_TARGETS += rebase-on-main-${REPO_NAME}
 .PHONY: rebase-on-main-${REPO_NAME}
 rebase-on-main-${REPO_NAME}:
 ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
-	@echo ""
-	@echo "Rebasing on origin/${REPO_DEFAULT} in ${REPO_DIR}:"
-	$(Q)git -C ${REPO_DIR} rebase origin/${REPO_DEFAULT}
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Rebasing on origin/${REPO_DEFAULT} in ${REPO_DIR}:" -- \
+		$(Q)git -C ${REPO_DIR} rebase origin/${REPO_DEFAULT}
 else
 	@echo "No repository in ${REPO_DIR}, cannot rebase."
 endif
@@ -209,9 +210,9 @@ ifeq ($(wildcard ${REPO_DIR}),${REPO_DIR})
 ifeq (${TAG_ARGS},)
 	@echo "Variable TAG_ARGS not set, not tagging ${REPO_DIR}."
 else
-	@echo ""
-	@echo "Tagging ${REPO_DIR} (${TAG_ARGS}):"
-	$(Q)git -C ${REPO_DIR} tag ${TAG_ARGS}
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Tagging ${REPO_DIR} (${TAG_ARGS}):" -- \
+		$(Q)git -C ${REPO_DIR} tag ${TAG_ARGS}
 endif
 else
 	@echo "No repository in ${REPO_DIR}, cannot tag."
@@ -292,26 +293,28 @@ show-config: show-config-workspace $(SHOW_CONFIG_TARGETS)
 
 .PHONY: describe-workspace
 describe-workspace:
-	@git log --pretty=tformat:'./: %H' -n 1
-	@git diff HEAD --quiet || echo "./ is dirty"
+	@dev/format.sh ${GIT_FORMATTING} run -- \
+		@git log --pretty=tformat:'./: %H' -n 1
+	@dev/format.sh ${GIT_FORMATTING} --no-skip-first-line eval -- \
+		'@git diff HEAD --quiet || echo "./ is dirty"'
 
 .PHONY: describe
 describe: describe-workspace ${DESCRIBE_TARGETS}
 
 .PHONY: fetch-workspace
 fetch-workspace:
-	@echo ""
-	@echo "Fetching at the workspace root."
-	$(Q)git fetch --all --quiet
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Fetching at the workspace root." -- \
+		$(Q)git fetch --all --quiet
 
 .PHONY: fetch
 fetch: fetch-workspace ${FETCH_TARGETS}
 
 .PHONY: pull-workspace
 pull-workspace:
-	@echo ""
-	@echo "Pulling at the workspace root."
-	$(Q)git pull --rebase
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Pulling at the workspace root." -- \
+		$(Q)git pull --rebase
 
 .PHONY: pull
 pull: pull-workspace
@@ -319,27 +322,27 @@ pull: pull-workspace
 
 .PHONY: push-workspace
 push-workspace:
-	@echo ""
-	@echo "Pushing at the workspace root."
-	$(Q)git push
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Pushing at the workspace root." -- \
+		$(Q)git push
 
 .PHONY: push
 push: push-workspace ${PUSH_TARGETS}
 
 .PHONY: peek-workspace
 peek-workspace:
-	@echo ""
-	@echo "Peeking into ./"
-	@git status --short --branch --untracked-files=normal ${GIT_PEEK_OPTS}
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Peeking into ./" -- \
+		@git status --short --branch --untracked-files=normal ${GIT_PEEK_OPTS}
 
 .PHONY: peek
 peek: peek-workspace ${PEEK_TARGETS}
 
 .PHONY: gitclean-workspace
 gitclean-workspace:
-	@echo ""
-	@echo "Cleaning ./:"
-	$(Q)git clean -xfd
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Cleaning ./:" -- \
+		$(Q)git clean -xfd
 
 .PHONY: gitclean
 gitclean: gitclean-workspace ${GITCLEAN_TARGETS}
@@ -353,18 +356,18 @@ ls-files: ls-files-workspace ${LS_FILES_TARGETS}
 
 .PHONY: checkout-main-workspace
 checkout-main-workspace:
-	@echo ""
-	@echo "Checking out branch main in ./:"
-	$(Q)git checkout main
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Checking out branch main in ./:" -- \
+		$(Q)git checkout main
 
 .PHONY: checkout-main
 checkout-main: checkout-main-workspace ${CHECKOUT_MAIN_TARGETS}
 
 .PHONY: rebase-on-main-workspace
 rebase-on-main-workspace:
-	@echo ""
-	@echo "Rebasing on origin/main in ./:"
-	$(Q)git rebase origin/main
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Rebasing on origin/main in ./:" -- \
+		$(Q)git rebase origin/main
 
 .PHONY: rebase-on-main
 rebase-on-main: rebase-on-main-workspace ${REBASE_ON_MAIN_TARGETS}
@@ -374,9 +377,9 @@ tag-workspace:
 ifeq (${TAG_ARGS},)
 	@echo "Variable TAG_ARGS not set, not tagging ./."
 else
-	@echo ""
-	@echo "Tagging ./ (${TAG_ARGS}):"
-	$(Q)git tag ${TAG_ARGS}
+	@dev/format.sh ${GIT_FORMATTING} run \
+		--heading="Tagging ./ (${TAG_ARGS}):" -- \
+		$(Q)git tag ${TAG_ARGS}
 endif
 
 .PHONY: tag


### PR DESCRIPTION
This PR defines new repo commands in the Makefile rules:
 * `make COMMIT_MESSAGE="foo" commit`
 * `make SELECT_BRANCH=branch/name checkout`
      Checks out `branch/name` in each repo and creates the branch if it does not exist.

Option for `make gitclean`: by default, it works as dry run, the effect can be applied with `make GITCLEAN_DRY_RUN=no gitclean`

Formatting: by default, the output of git commands is double spaced and indented. The formatting can be changed with:
 * `make 'GIT_FORMATTING=--indent --skip-first-line' git-command`: double spaced and indented;
 * `make 'GIT_FORMATTING=--skip-first-line' git-command`: only double spaced;
 * `make 'GIT_FORMATTING=--indent' git-command`: only indented;
 * `make 'GIT_FORMATTING=' git-command`: unformatted. 